### PR TITLE
Support max.poll.records and max.poll.interval.ms of Kafka Consumer

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -55,13 +55,19 @@ parser {
     topic = "markeplace_crawler-events-ozon_request_handled-version_1"
     topic = ${?PARSER_KAFKA_CONSUMER_TOPIC}
 
-    commit-every-n-offsets = 64
+    max-poll-records = 250
+    max-poll-records = ${?PARSER_KAFKA_CONSUMER_MAX_POLL_RECORDS}
+
+    max-poll-interval = 20 minutes
+    max-poll-interval = ${?PARSER_KAFKA_CONSUMER_MAX_POLL_INTERVAL}
+
+    commit-every-n-offsets = 256
     commit-every-n-offsets = ${?PARSER_KAFKA_CONSUMER_COMMIT_EVERY_N_OFFSETS}
     
     commit-timeout = 30 seconds
     commit-timeout = ${?PARSER_KAFKA_CONSUMER_COMMIT_TIMEOUT}
 
-    commit-time-window = 10 milliseconds
+    commit-time-window = 500 milliseconds
     commit-time-window = ${?PARSER_KAFKA_CONSUMER_COMMIT_TIME_WINDOW}
   }
 
@@ -90,6 +96,12 @@ crawler {
 
     topic = "marketplace_crawler-commands-handle_ozon_request-version_1"
     topic = ${?CRAWLER_KAFKA_CONSUMER_TOPIC}
+
+    max-poll-records = 250
+    max-poll-records = ${?CRAWLER_KAFKA_CONSUMER_MAX_POLL_RECORDS}
+
+    max-poll-interval = 30 minutes
+    max-poll-interval = ${?CRAWLER_KAFKA_CONSUMER_MAX_POLL_INTERVAL}
 
     commit-every-n-offsets = 64
     commit-every-n-offsets = ${?CRAWLER_KAFKA_CONSUMER_COMMIT_EVERY_N_OFFSETS}

--- a/src/main/scala/marketplace/config/KafkaConsumerConfig.scala
+++ b/src/main/scala/marketplace/config/KafkaConsumerConfig.scala
@@ -12,7 +12,9 @@ import pureconfig.module.catseffect.syntax._
 final case class KafkaConsumerConfig(
   groupId: String,
   topic: String,
-  commitTimeout: FiniteDuration = 15 seconds,
+  maxPollRecords: Option[Int],
+  maxPollInterval: Option[FiniteDuration],
+  commitTimeout: Option[FiniteDuration],
   commitTimeWindow: FiniteDuration,
   commitEveryNOffsets: Int
 )


### PR DESCRIPTION
Probably fixes the following problem:
```
fs2.CompositeFailure: Multiple exceptions were thrown (6), first org.apache.kafka.clients.consumer.CommitFailedException: Commit cannot be completed since the group has already rebalanced and assigned the partitions to another member. This means that the time between subsequent calls to poll() was longer than the configured max.poll.interval.ms, which typically implies that the poll loop is spending too much time message processing. You can address this either by increasing max.poll.interval.ms or by reducing the maximum size of batches returned in poll() with max.poll.records.
```