### PR TITLE
fetchMaxBytes and maxPartitionFetchBytes parameters are added into KafkaConsumerConfig

### DIFF
--- a/modules/domain/src/main/scala/net/dalytics/config/KafkaConsumerConfig.scala
+++ b/modules/domain/src/main/scala/net/dalytics/config/KafkaConsumerConfig.scala
@@ -13,11 +13,13 @@ final case class KafkaConsumerConfig(
   groupId: String,
   topic: String,
   enableAutoCommit: Option[Boolean],
-  maxPollRecords: Option[Int],
-  maxPollInterval: Option[FiniteDuration],
-  commitTimeout: Option[FiniteDuration],
-  commitTimeWindow: FiniteDuration,
-  commitEveryNOffsets: Int,
+  fetchMaxBytes: Option[Long],             // The maximum amount of data the server should return for a fetch request.
+  maxPartitionFetchBytes: Option[Long],    // The maximum amount of data per-partition the server will return.
+  maxPollRecords: Option[Int],             // The maximum number of records returned in a single call to poll().
+  maxPollInterval: Option[FiniteDuration], // The maximum delay between invocations of poll() when using consumer group management.
+  commitTimeout: Option[FiniteDuration],   // FS2 Kafka. The timeout for offset commits.
+  commitTimeWindow: FiniteDuration,        // FS2 Kafka. Commits offsets in batches of every `commitEveryNOffsets` offsets or
+  commitEveryNOffsets: Int,                //            time window of length `commitTimeWindow`, whichever happens first.
   maxConcurrentPerTopic: Int
 )
 

--- a/modules/domain/src/main/scala/net/dalytics/config/KafkaStreamsConfig.scala
+++ b/modules/domain/src/main/scala/net/dalytics/config/KafkaStreamsConfig.scala
@@ -13,7 +13,7 @@ final case class KafkaStreamsConfig(
   applicationId: String,
   closeTimeout: FiniteDuration,
   sourceTopic: String,
-  sinkTopic: String,              // The number of threads to execute stream processing.
+  sinkTopic: String,
   numberOfStreamThreads: Int,     // The number of threads to execute stream processing.
   commitInterval: FiniteDuration, // The frequency in milliseconds with which to save the position of the processor.
   cacheMaxBytesBuffering: Long,   // Maximum number of memory bytes to be used for buffering across all threads.

--- a/modules/parser/src/main/resources/application.conf
+++ b/modules/parser/src/main/resources/application.conf
@@ -15,18 +15,31 @@ kafka-consumer {
   topic = "marketplace_handler-events-ozon_request_handled-version_1"
   topic = ${?PARSER_KAFKA_CONSUMER_TOPIC}
 
+  # The maximum amount of data the server should return for a fetch request.
+  fetch-max-bytes = 83886080 # 80MB
+  fetch-max-bytes = ${?PARSER_KAFKA_CONSUMER_FETCH_MAX_BYTES}
+
+  # The maximum amount of data per-partition the server will return.
+  max-partition-fetch-bytes = 5242880 # 5MB
+  max-partition-fetch-bytes = ${?PARSER_KAFKA_CONSUMER_MAX_PARTITION_FETCH_BYTES}
+
+  # The maximum number of records returned in a single call to poll().
   max-poll-records = 8192
   max-poll-records = ${?PARSER_KAFKA_CONSUMER_MAX_POLL_RECORDS}
 
+  # The maximum delay between invocations of poll() when using consumer group management.
   max-poll-interval = 5 minutes
   max-poll-interval = ${?PARSER_KAFKA_CONSUMER_MAX_POLL_INTERVAL}
 
+  # FS2 Kafka. The timeout for offset commits.
   commit-timeout = 120 seconds
   commit-timeout = ${?PARSER_KAFKA_CONSUMER_COMMIT_TIMEOUT}
 
+  # FS2 Kafka. Commits offsets in batches of every `commit-every-n-offsets` offsets or ...
   commit-every-n-offsets = 1024
   commit-every-n-offsets = ${?PARSER_KAFKA_CONSUMER_COMMIT_EVERY_N_OFFSETS}
 
+  # ... time window of length `commit-time-window`, whichever happens first.
   commit-time-window = 1600 milliseconds
   commit-time-window = ${?PARSER_KAFKA_CONSUMER_COMMIT_TIME_WINDOW}
 


### PR DESCRIPTION
* fetch.max.bytes describes the maximum amount of data the server should return for a fetch request.
* max.partition.fetch.bytes describes the maximum amount of data per-partition the server will return.